### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -1,4 +1,6 @@
 name: Build and deploy to Kubernetes
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Wilcolab/Anythink-Market-dvgwlxvq/security/code-scanning/7](https://github.com/Wilcolab/Anythink-Market-dvgwlxvq/security/code-scanning/7)

To resolve this issue, you should specify a `permissions` block to scope down the permissions granted by the GITHUB_TOKEN for the workflow. Since your workflow only needs to check out code (and does not need to write to the repository, access issues, PRs, etc.), the least privilege necessary is generally `contents: read`. 

The best and simplest way to apply this is to add a `permissions` key at the workflow root (before `jobs:`), so that all jobs inherit it. If later, a specific job requires additional permission, you can further override the setting for that particular job.

**Steps to fix:**
- Edit `.github/workflows/k8s.yml`.
- Add the following lines after the workflow name (after `name: Build and deploy to Kubernetes`), and before `on:`:
  ```yaml
  permissions:
    contents: read
  ```
This restricts the GITHUB_TOKEN to the minimum scope necessary for source checkout and reading contents, which matches the needs of this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
