### PR TITLE
Potential fix for code scanning alert no. 29: Database query built from user-controlled sources

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -54,8 +54,8 @@ router.get("/", auth.optional, function(req, res, next) {
   }
 
   Promise.all([
-    req.query.seller ? User.findOne({ username: req.query.seller }) : null,
-    req.query.favorited ? User.findOne({ username: req.query.favorited }) : null
+    req.query.seller ? User.findOne({ username: { $eq: req.query.seller } }) : null,
+    req.query.favorited ? User.findOne({ username: { $eq: req.query.favorited } }) : null
   ])
     .then(function(results) {
       var seller = results[0];


### PR DESCRIPTION
Potential fix for [https://github.com/Wilcolab/Anythink-Market-dvgwlxvq/security/code-scanning/29](https://github.com/Wilcolab/Anythink-Market-dvgwlxvq/security/code-scanning/29)

To fix this issue, you should ensure that user-supplied data (`req.query.favorited` and, for consistency, `req.query.seller`) is interpreted strictly as a literal value and not as a MongoDB query object/operator. The most robust and idiomatic way to do so is to use the `$eq` operator in the query objects for `findOne`, e.g., `{ username: { $eq: req.query.favorited } }`. This prevents MongoDB from interpreting an object submitted by the user as an operator and ensures that only documents matching the literal value are returned.

Make the following changes in file `backend/routes/api/items.js`:
- Replace `User.findOne({ username: req.query.seller })` on line 57 with `User.findOne({ username: { $eq: req.query.seller } })`.
- Replace `User.findOne({ username: req.query.favorited })` on line 58 with `User.findOne({ username: { $eq: req.query.favorited } })`.

No new methods or imports are needed because this uses native MongoDB operator syntax.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
