### PR TITLE
Potential fix for code scanning alert no. 25: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,8 @@
     "passport-local": "1.0.0",
     "request": "2.69.0",
     "slug": "0.9.1",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "newman": "^3.8.2",


### PR DESCRIPTION
Potential fix for [https://github.com/Wilcolab/Anythink-Market-dvgwlxvq/security/code-scanning/25](https://github.com/Wilcolab/Anythink-Market-dvgwlxvq/security/code-scanning/25)

To resolve the issue, introduce rate limiting to limit the number of requests a user (or IP) can make to the affected route within a certain timeframe. The best practice is to use a well-known middleware like `express-rate-limit`. This should be required at the top of the file and then applied as middleware to the specific route. The limiter can be configured specifically for this route (for example, allowing 10 delete requests per 15 minutes per IP/user), which is a sensible threshold for deleting comments and should not interfere with normal use.

The following needs to be done in `backend/routes/api/items.js`:

1. Import `express-rate-limit` using `require`.
2. Define a specific limiter instance for the delete comment route.
3. Apply the limiter as additional middleware to the `DELETE /:item/comments/:comment` route.
4. Ensure the code changes only affect the relevant file and region.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
