### PR TITLE
Potential fix for code scanning alert no. 1: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/wilco-actions.yml
+++ b/.github/workflows/wilco-actions.yml
@@ -22,11 +22,10 @@ jobs:
         uses: supercharge/mongodb-github-action@1.6.0
         with:
           mongodb-version: "4.4"
-
+  
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
-        secrets: ${{"WILCO_ENGINE_URL":"your_secret_value"}}
-
+          secrets: '{"WILCO_ENGINE_URL": "${{ secrets.WILCO_ENGINE_URL }}"}'
       - name: Wilco checks
         id: Wilco
         uses: trywilco/actions@main

--- a/.github/workflows/wilco-actions.yml
+++ b/.github/workflows/wilco-actions.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
-          secrets: WILCO_ENGINE_URL=${{ secrets.WILCO_ENGINE_URL }}
+        secrets: ${{"WILCO_ENGINE_URL":"your_secret_value"}}
 
       - name: Wilco checks
         id: Wilco

--- a/.github/workflows/wilco-actions.yml
+++ b/.github/workflows/wilco-actions.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: oNaiPs/secrets-to-env-action@v1
         with:
-          secrets: ${{ toJSON(secrets) }}
+          secrets: WILCO_ENGINE_URL=${{ secrets.WILCO_ENGINE_URL }}
 
       - name: Wilco checks
         id: Wilco


### PR DESCRIPTION
Potential fix for [https://github.com/Wilcolab/Anythink-Market-dvgwlxvq/security/code-scanning/1](https://github.com/Wilcolab/Anythink-Market-dvgwlxvq/security/code-scanning/1)

To resolve this issue, you should **only pass the necessary secret(s) to the action(s) that need them** instead of all secrets. In this workflow, line 28 passes all secrets as a JSON object. Instead, explicitly enumerate the required secrets. 

Reviewing the workflow, only `WILCO_ENGINE_URL` is used in the job (line 34). If the `secrets-to-env-action` step truly needs this secret as an environment variable, pass that single secret. The corrected block would replace `secrets: ${{ toJSON(secrets) }}` with `secrets: WILCO_ENGINE_URL=${{ secrets.WILCO_ENGINE_URL }}`.

**Changes needed:**  
- In `.github/workflows/wilco-actions.yml`, modify the `secrets-to-env-action` step to only expose `WILCO_ENGINE_URL`.
- No additional imports or external definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
